### PR TITLE
chorus: update docusaurus version

### DIFF
--- a/docs/website/package.json
+++ b/docs/website/package.json
@@ -16,9 +16,9 @@
     "typecheck": "tsc"
   },
   "dependencies": {
-    "@docusaurus/core": "^2.0.0-beta.15",
-    "@docusaurus/module-type-aliases": "^2.0.0-beta.15",
-    "@docusaurus/preset-classic": "^2.0.0-beta.15",
+    "@docusaurus/core": "^2.0.0-beta.17",
+    "@docusaurus/module-type-aliases": "^2.0.0-beta.17",
+    "@docusaurus/preset-classic": "^2.0.0-beta.17",
     "@mdx-js/react": "^1.6.22",
     "@svgr/webpack": "^6.2.0",
     "clsx": "^1.1.1",


### PR DESCRIPTION
A warning:

At first, after update the Docusaurus version, I ran `yarn` on the root to know if something would happen. Because of this, the `yarn.lock` file had an big modification (500+ lines). I don't know if this was necessary, so I chose to only update the Docusaurus and push it.